### PR TITLE
Fix lower bound for Python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "nnssl"
 version = "0.1"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 description = "nnSSL is a framework for self-supervised pre-training 3D medical images easily integrateable with the nnU-Net framework."
 readme = "readme.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
The lower bound must be compatible with the dependencies, and `blosc2==3.0.0b1` requires Python >= 3.10:

https://github.com/Blosc/python-blosc2/blob/c394a04f0ebaeae6d185b19ac34baffa8deb762f/pyproject.toml#L34