### PR TITLE
Fix type error for number of processes

### DIFF
--- a/src/nnssl/experiment_planning/plan_and_preprocess_api.py
+++ b/src/nnssl/experiment_planning/plan_and_preprocess_api.py
@@ -105,7 +105,7 @@ def preprocess_dataset(
     verbose: bool = False,
 ) -> None:
     if not isinstance(num_processes, list):
-        num_processes = list(num_processes)
+        num_processes = [num_processes]
     if len(num_processes) == 1:
         num_processes = num_processes * len(configurations)
     if len(num_processes) != len(configurations):


### PR DESCRIPTION
This failed on my machine because of this:

```python
>>> list(3)
Traceback (most recent call last):
  File "<python-input-0>", line 1, in <module>
    list(3)
    ~~~~^^^
TypeError: 'int' object is not iterable
```