### PR TITLE
Fix python minimum version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "nnssl"
 version = "0.1"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 description = "nnSSL is a framework for self-supervised pre-training 3D medical images easily integrateable with the nnU-Net framework."
 readme = "readme.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Several files contain `override` from `typing` module.

https://github.com/search?q=repo%3AMIC-DKFZ%2Fnnssl%20override&type=code

This is only available from Python 3.12 onwards. https://peps.python.org/pep-0698/